### PR TITLE
1단계 - 학습테스트 실습

### DIFF
--- a/src/test/java/study/SetTest.java
+++ b/src/test/java/study/SetTest.java
@@ -33,4 +33,14 @@ public class SetTest {
     void testContains(int checkValue) {
         assertThat(numbers.contains(checkValue)).isTrue();
     }
+
+    @ParameterizedTest
+    @CsvSource(value = {"1", "2", "3", "4", "5"})
+    void testRemove(int checkValue) {
+        if (1 <= checkValue && checkValue < 4) {
+            assertThat(numbers.contains(checkValue)).isTrue();
+        } else {
+            assertThat(numbers.contains(checkValue)).isFalse();
+        }
+    }
 }

--- a/src/test/java/study/SetTest.java
+++ b/src/test/java/study/SetTest.java
@@ -1,0 +1,30 @@
+package study;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class SetTest {
+    private Set<Integer> numbers;
+
+    @BeforeEach
+    void setUp() {
+        numbers = new HashSet<>();
+        numbers.add(1);
+        numbers.add(1);
+        numbers.add(2);
+        numbers.add(3);
+    }
+
+    @Test
+    void testForSize() {
+        assertThat(numbers.size()).isEqualTo(3);
+    }
+}

--- a/src/test/java/study/SetTest.java
+++ b/src/test/java/study/SetTest.java
@@ -27,4 +27,10 @@ public class SetTest {
     void testForSize() {
         assertThat(numbers.size()).isEqualTo(3);
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    void testContains(int checkValue) {
+        assertThat(numbers.contains(checkValue)).isTrue();
+    }
 }

--- a/src/test/java/study/StringTest.java
+++ b/src/test/java/study/StringTest.java
@@ -1,0 +1,37 @@
+package study;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringTest {
+
+    @Test
+    public void splitTestToArrayMultiValue() {
+
+        //given
+        String inputValue = "1,2";
+
+        // when
+        String[] split = inputValue.split(",");
+
+        // then
+        assertThat(split).contains("1", "2");
+        assertThat(split).containsExactly("1", "2");
+    }
+
+    @Test
+    public void splitTestToArraySingleValue() {
+
+        //given
+        String inputValue = "1,";
+
+        // when
+        String[] split = inputValue.split(",");
+
+        // then
+        assertThat(split).contains("1");
+        assertThat(split).containsExactly("1");
+    }
+
+}

--- a/src/test/java/study/StringTest.java
+++ b/src/test/java/study/StringTest.java
@@ -1,8 +1,12 @@
 package study;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class StringTest {
 
@@ -42,5 +46,26 @@ public class StringTest {
 
         // when & then
         assertThat(testForParenthesis.substring(1, 4)).isEqualTo("1,2");
+    }
+
+    @DisplayName("charAt 메서드를 활용해 특정 위치의 문자를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"abc"})
+    public void testForCharAt(String inputValue) {
+
+        // when & then
+        assertThat('a').isEqualTo(inputValue.charAt(0));
+        assertThat('b').isEqualTo(inputValue.charAt(1));
+        assertThat('c').isEqualTo(inputValue.charAt(2));
+    }
+
+    @DisplayName("charAt 으로 주어진 문자열의 길이보다 큰 값을 조회 할 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"abc"})
+    public void testForCharAtException(String inputValue) {
+
+        // when & then
+        assertThatThrownBy(() -> inputValue.charAt(inputValue.length() + 1))
+                .isInstanceOf(StringIndexOutOfBoundsException.class);
     }
 }

--- a/src/test/java/study/StringTest.java
+++ b/src/test/java/study/StringTest.java
@@ -34,4 +34,13 @@ public class StringTest {
         assertThat(split).containsExactly("1");
     }
 
+    @Test
+    public void testForParenthesis() {
+
+        // given
+        String testForParenthesis = "(1,2)";
+
+        // when & then
+        assertThat(testForParenthesis.substring(1, 4)).isEqualTo("1,2");
+    }
 }


### PR DESCRIPTION
1단계 학습테스트를 완료 했습니다. 
진행 중에 한가지 궁금한 점이 있어서 남깁니다! 


```
@ParameterizedTest
@ValueSource(strings = {"1,2", "1,"})
public void splitTestToArray(String inputValue) {

    // when
    String[] split = inputValue.split(",");

    // then
    Assertions.assertThat(split).contains("1", "2");
    Assertions.assertThat(split).containsExactly("1", "2");
}
```

위에 코드는 서로 다른 길이의  "1,2", "1," 파라미터에 대한 split 테스트 코드를 중복으로 작성하고 싶지 않아서 떠올린 코드입니다.
하지만 중복을 제거하는 대신 서로 다른 파라미터를 어떻게 테스트하면 좋을지 몰라 찾아본 결과 아래 @MethodSource 를 통해서 입력값과 결괏값을 입력할 수 있다고 학습했습니다. 

```
private static Stream<Arguments> splitTestCases() {
    return Stream.of(
        Arguments.of("1,2", new String[]{"1", "2"}),
        Arguments.of("1,", new String[]{"1", ""})
    );
```

하지만 이러한 경우 작성하게 되는 코드는 본 split 테스트 코드 + @MethodSource 테스트 결괏값 으로 증가하게 되어 결과적으로는 코드를 보게 될 때 가독성이 복잡해질 것 같아 결국 중복이 발생하는 테스트 코드를 작성하게 되었습니다. 

결국 제가 선택한 방법은 single테스트로는 "1," 을 multi 테스트로는 "1,2" 이 둘을 나눠서 테스트코드를 중복으로 작성하는 방안을 선택했습니다. 

**Q. 위와 같은 사례에서 중복과 가독성 사이에 트레이드 오프가 발생하게 되면 코치님은 무엇을 우선시 하시는지 궁금합니다.!** 

